### PR TITLE
feat: add ability to scroll down through the archive years and months

### DIFF
--- a/frontend/styles/archive.module.scss
+++ b/frontend/styles/archive.module.scss
@@ -20,6 +20,8 @@
 
 .navInner {
   position: fixed;
+  max-height: 85%;
+  overflow-y: scroll;
 }
 
 .bananaDates {


### PR DESCRIPTION
Hi. Thanks for making this site! Appreciate it's been a few years since the last update so not sure if you're accepting contributions but thought I'd give it a go. I found when I was viewing the archive page - https://doyoutrackid.com/archive?month=may&year=2025 - I wasn't able to scroll down through the years and months. Tweaked the CSS to enable this